### PR TITLE
Potential fix for code scanning alert no. 2: Cleartext logging of sensitive information

### DIFF
--- a/scripts/generate_addresses/src/main.rs
+++ b/scripts/generate_addresses/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
     // Display inputs for verification
     println!("Mnemonic Phrase: {}", mnemonic_phrase);
     println!("Derivation Path: {}", derivation_path_str);
-    println!("Passphrase: {}", if passphrase.is_empty() { "<empty>" } else { passphrase });
+    println!("Passphrase: {}", if passphrase.is_empty() { "<empty>" } else { "<redacted>" });
 
     // Parse mnemonic
     let mnemonic = match Mnemonic::parse_in(Language::English, mnemonic_phrase) {


### PR DESCRIPTION
Potential fix for [https://github.com/yanncarlier/btcx_tools/security/code-scanning/2](https://github.com/yanncarlier/btcx_tools/security/code-scanning/2)

In general, to fix cleartext logging of sensitive data, avoid logging the secret field entirely (best), or if absolutely necessary, redact or mask it so the full value cannot be reconstructed. For cryptographic secrets like passphrases and seeds, omission is strongly preferred to masking or encryption-for-logging.

For this specific file (`scripts/generate_addresses/src/main.rs`):

1. **Stop printing the passphrase**: Replace the current line 26 that prints the passphrase value with a redacted/static message that indicates whether a passphrase was provided, without revealing its content.
2. **Consider also avoiding seed logging**: The seed produced at line 38–39 is also highly sensitive, but CodeQL flagged only the passphrase. If you want to stay as close as possible to the original functionality while addressing only the reported issue, we will change only the passphrase logging. Seed logging could be removed in a follow-up hardening pass.

Concrete change:
- Modify line 26 from:
  ```rust
  println!("Passphrase: {}", if passphrase.is_empty() { "<empty>" } else { passphrase });
  ```
  to something like:
  ```rust
  println!("Passphrase: {}", if passphrase.is_empty() { "<empty>" } else { "<redacted>" });
  ```
  This preserves the information about whether a passphrase is set (which may be useful for verification) without exposing the passphrase itself. No imports or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
